### PR TITLE
compilation update

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -7,3 +7,4 @@ done
 
 cp package*.json dist/
 cp README.md dist/
+cp LICENSE dist/


### PR DESCRIPTION
It looks like version 2.4.2 (the latest version of the module as of today), doesn't include the license field in the published package.json or a license file.

This change updates the compilation so that the license file is copied over to the dist.

**Checklist**
- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
